### PR TITLE
Update HydroDyn with output channel, better WaveTMax

### DIFF
--- a/OpenFAST/IEA-22-280-RWT-Monopile/IEA-22-280-RWT_HydroDyn.dat
+++ b/OpenFAST/IEA-22-280-RWT-Monopile/IEA-22-280-RWT_HydroDyn.dat
@@ -8,7 +8,7 @@ False                  Echo        - Echo the input file data (flag)
 ---------------------- WAVES ---------------------------------------------------
 2                      WaveMod     - Incident wave kinematics model {0: none=still water, 1: regular (periodic), 1P#: regular with user-specified phase, 2: JONSWAP/Pierson-Moskowitz spectrum (irregular), 3: White noise spectrum (irregular), 4: user-defined spectrum from routine UserWaveSpctrm (irregular), 5: Externally generated wave-elevation time series, 6: Externally generated full wave-kinematics time series [option 6 is invalid for PotMod/=0]} (switch)
 0                      WaveStMod   - Model for stretching incident wave kinematics to instantaneous free surface {0: none=no stretching, 1: vertical stretching, 2: extrapolation stretching, 3: Wheeler stretching} (switch) [unused when WaveMod=0 or when PotMod/=0]
-1                      WaveTMax    - Analysis time for incident wave calculations (sec) [unused when WaveMod=0; determines WaveDOmega=2Pi/WaveTMax in the IFFT]
+3600                      WaveTMax    - Analysis time for incident wave calculations (sec) [unused when WaveMod=0; determines WaveDOmega=2Pi/WaveTMax in the IFFT]
 0.25                   WaveDT      - Time step for incident wave calculations     (sec) [unused when WaveMod=0; 0.1<=WaveDT<=1.0 recommended; determines WaveOmegaMax=Pi/WaveDT in the IFFT]
 7.6                    WaveHs      - Significant wave height of incident waves (meters) [used only when WaveMod=1, 2, or 3]
 13.0                   WaveTp      - Peak-spectral period of incident waves       (sec) [used only when WaveMod=1 or 2]
@@ -145,4 +145,5 @@ False                  OutAll      - Output all user-specified member and joint 
 ES11.4e2               OutFmt      - Output format for numerical results (quoted string) [not checked for validity!]
 A11                    OutSFmt     - Output format for header strings (quoted string) [not checked for validity!]
 ---------------------- OUTPUT CHANNELS -----------------------------------------
+"Wave1Elev"               - Wave elevation at the WAMIT reference point (0,0)
 END of output channels and end of file. (the word "END" must appear in the first 3 columns of this line)


### PR DESCRIPTION
This fixed the seg fault we are seeing in the CI.  I opened bug report in [OpenFAST here](https://github.com/OpenFAST/openfast/issues/1863).