### PR TITLE
0.09% damping on 0.16Hz first system mode

### DIFF
--- a/OpenFAST/IEA-22-280-RWT-Monopile/IEA-22-280-RWT_SubDyn.dat
+++ b/OpenFAST/IEA-22-280-RWT-Monopile/IEA-22-280-RWT_SubDyn.dat
@@ -11,9 +11,9 @@ False                  GuyanLoadCorrection - Include extra moment from lever arm
 1                      NDiv        - Number of sub-elements per member
 True                   CBMod       - [T/F] If True perform C-B reduction, else full FEM dofs will be retained. If True, select Nmodes to retain in C-B reduced system.
 0                      Nmodes      - Number of internal modes to retain (ignored if CBMod=False). If Nmodes=0 --> Guyan Reduction.
-1.000000               JDampings   - Damping Ratios for each retained mode (% of critical) If Nmodes>0, list Nmodes structural damping ratios for each retained mode (% of critical), or a single damping ratio to be applied to all retained modes. (last entered value will be used for all remaining modes).
-0                      GuyanDampMod - Guyan damping {0=none, 1=Rayleigh Damping, 2=user specified 6x6 matrix}.
-0.0        0.0        RayleighDamp - Mass and stiffness proportional damping  coefficients (Rayleigh Damping) [only if GuyanDampMod=1].
+1.                     JDampings   - Damping Ratios for each retained mode (% of critical) If Nmodes>0, list Nmodes structural damping ratios for each retained mode (% of critical), or a single damping ratio to be applied to all retained modes. (last entered value will be used for all remaining modes).
+1                      GuyanDampMod - Guyan damping {0=none, 1=Rayleigh Damping, 2=user specified 6x6 matrix}.
+0.0        0.00183     RayleighDamp - Mass and stiffness proportional damping  coefficients (Rayleigh Damping) [only if GuyanDampMod=1].
 6                      GuyanDampSize - Guyan damping matrix (6x6) [only if GuyanDampMod=2].
            0.0            0.0            0.0            0.0            0.0            0.0
            0.0            0.0            0.0            0.0            0.0            0.0


### PR DESCRIPTION
Target 0.09% structural damping ratio on 0.16Hz first system mode. Damping is assumed stiffness proportional and second modes have higher damping