### PR TITLE
tweak damping again

### DIFF
--- a/OpenFAST/IEA-22-280-RWT-Monopile/IEA-22-280-RWT_ElastoDyn_tower.dat
+++ b/OpenFAST/IEA-22-280-RWT-Monopile/IEA-22-280-RWT_ElastoDyn_tower.dat
@@ -2,10 +2,10 @@
 Generated with AeroElasticSE FAST driver
 ---------------------- TOWER PARAMETERS ----------------------------------------
 30                     NTwInpSt    - Number of input stations to specify tower geometry
-0.5                    TwrFADmp(1) - Tower 1st fore-aft mode structural damping ratio (%)
-0.5                    TwrFADmp(2) - Tower 2nd fore-aft mode structural damping ratio (%)
-0.5                    TwrSSDmp(1) - Tower 1st side-to-side mode structural damping ratio (%)
-0.5                    TwrSSDmp(2) - Tower 2nd side-to-side mode structural damping ratio (%)
+0.33                   TwrFADmp(1) - Tower 1st fore-aft mode structural damping ratio (%)
+1.30                   TwrFADmp(2) - Tower 2nd fore-aft mode structural damping ratio (%)
+0.33                   TwrSSDmp(1) - Tower 1st side-to-side mode structural damping ratio (%)
+1.70                   TwrSSDmp(2) - Tower 2nd side-to-side mode structural damping ratio (%)
 ---------------------- TOWER ADJUSTMUNT FACTORS --------------------------------
 1.0                    FAStTunr(1) - Tower fore-aft modal stiffness tuner, 1st mode (-)
 1.0                    FAStTunr(2) - Tower fore-aft modal stiffness tuner, 2nd mode (-)

--- a/OpenFAST/IEA-22-280-RWT-Monopile/IEA-22-280-RWT_SubDyn.dat
+++ b/OpenFAST/IEA-22-280-RWT-Monopile/IEA-22-280-RWT_SubDyn.dat
@@ -13,7 +13,7 @@ True                   CBMod       - [T/F] If True perform C-B reduction, else f
 0                      Nmodes      - Number of internal modes to retain (ignored if CBMod=False). If Nmodes=0 --> Guyan Reduction.
 1.                     JDampings   - Damping Ratios for each retained mode (% of critical) If Nmodes>0, list Nmodes structural damping ratios for each retained mode (% of critical), or a single damping ratio to be applied to all retained modes. (last entered value will be used for all remaining modes).
 1                      GuyanDampMod - Guyan damping {0=none, 1=Rayleigh Damping, 2=user specified 6x6 matrix}.
-0.0        0.00072     RayleighDamp - Mass and stiffness proportional damping  coefficients (Rayleigh Damping) [only if GuyanDampMod=1].
+0.0        0.00183     RayleighDamp - Mass and stiffness proportional damping  coefficients (Rayleigh Damping) [only if GuyanDampMod=1].
 6                      GuyanDampSize - Guyan damping matrix (6x6) [only if GuyanDampMod=2].
            0.0            0.0            0.0            0.0            0.0            0.0
            0.0            0.0            0.0            0.0            0.0            0.0

--- a/OpenFAST/IEA-22-280-RWT-Semi/IEA-22-280-RWT-Semi_ElastoDyn_tower.dat
+++ b/OpenFAST/IEA-22-280-RWT-Semi/IEA-22-280-RWT-Semi_ElastoDyn_tower.dat
@@ -2,10 +2,10 @@
 Generated with AeroElasticSE FAST driver
 ---------------------- TOWER PARAMETERS ----------------------------------------
 30                     NTwInpSt    - Number of input stations to specify tower geometry
-0.5                    TwrFADmp(1) - Tower 1st fore-aft mode structural damping ratio (%)
-0.5                    TwrFADmp(2) - Tower 2nd fore-aft mode structural damping ratio (%)
-0.5                    TwrSSDmp(1) - Tower 1st side-to-side mode structural damping ratio (%)
-0.5                    TwrSSDmp(2) - Tower 2nd side-to-side mode structural damping ratio (%)
+0.33                   TwrFADmp(1) - Tower 1st fore-aft mode structural damping ratio (%)
+1.30                   TwrFADmp(2) - Tower 2nd fore-aft mode structural damping ratio (%)
+0.33                   TwrSSDmp(1) - Tower 1st side-to-side mode structural damping ratio (%)
+1.70                   TwrSSDmp(2) - Tower 2nd side-to-side mode structural damping ratio (%)
 ---------------------- TOWER ADJUSTMUNT FACTORS --------------------------------
 1.0                    FAStTunr(1) - Tower fore-aft modal stiffness tuner, 1st mode (-)
 1.0                    FAStTunr(2) - Tower fore-aft modal stiffness tuner, 2nd mode (-)


### PR DESCRIPTION
Following guidance from @RBergua, I'm tweaking structural damping of tower and monopile again:

Monopile damping is now set in SubDyn to use the stiffness proportional damping term β
β = damping/(π ∗ freq)
where damping is 0.09% and freq is 0.16 Hz. These values correspond to the full system damping and frequency of the first FA mode from HAWC2
β = 0.00092 / (π ∗ 0.16) = 0.00183

Tower structural damping of the first FA and SS modes in ElastoDyn is set as
damping * uncoupled_freq (isolated tower) / coupled_freq (full RNA+tower+monopile)
For the IEA, that translates to
0.00092 * 0.583 Hz / 0.16 Hz = 0.33%

The damping for the second modes of the tower are tuned manually to achieve target damping of 0.517% and 0.537% for second SS and second FA modes of the full system, respectively.

When I linearize the model, I now get

![image](https://github.com/IEAWindTask37/IEA-22-280-RWT/assets/20641647/338890a4-ad4f-4891-b2da-e4accd6fa49e)

Note that:
1) I've propagated the values of structural damping of the isolated tower in ElastoDyn to the floating tower. We will need to review these values @dzalkind 
2) When modeling the system without the monopile, structural damping in ElastoDyn will no longer match the values from HAWC2. In this case, a user should change the 0.33% to 0.5% for the first modes and 2.1678% and 2.1698 for the second modes. Caution: if running the isolated tower to check these values from a linearization, the user will also need to update the mode shapes!!

